### PR TITLE
Fix error when occupancy data is missing

### DIFF
--- a/sanntid.js
+++ b/sanntid.js
@@ -165,7 +165,7 @@ var app = {
 					line: visit.MonitoredVehicleJourney.PublishedLineName,
 					vehicle: visit.MonitoredVehicleJourney.VehicleMode,
 					atStop: (visit.MonitoredVehicleJourney.MonitoredCall.VehicleAtStop ? true : false),
-					occupancy: visit.Extensions.OccupancyData.OccupancyPercentage,
+					occupancy: visit.Extensions.OccupancyData ? visit.Extensions.OccupancyData.OccupancyPercentage : 0,
 					time: arrival
 				});
 			}


### PR DESCRIPTION
Not sure why this occurs, but some entries don’t have it.
