### PR TITLE
Return unlimited results from the module

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "author": "novasism",
   "license": "ISC",
   "dependencies": {
+    "commander": "^2.9.0",
     "jquery": "^2.1.3",
     "json-query": "^1.4.0",
     "moment": "^2.9.0",

--- a/sanntid.js
+++ b/sanntid.js
@@ -141,7 +141,7 @@ var app = {
 			direction = (direction ? direction : false),
 			moment = require('moment');
 
-		for (var i = 0; i < 5; i++) {
+		for (var i = 0; i < data.length; i++) {
 			var visit = data[i];
 
 			if (typeof visit === 'undefined') {


### PR DESCRIPTION
IMO the module shouldn't limit the amount of results retrieved from Ruter. The command line tool still limits it to 5, but you can choose how many results to retrieve using the `-n` option.

Adding the `commander` module also gives you the help (`-h`) and version (`-v`) options.

5 results

``` shell
node sanntid.js lol
```

10 results

``` shell
node sanntid.js -n 10 lol
```

1 result

``` shell
node sanntid.js -n 1 lol
```

Etc.
